### PR TITLE
Build Action

### DIFF
--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -7,6 +7,8 @@ on:
   push:
   pull_request:
     branches: ["main"]
+  schedule:
+    - cron:  '0 0 * * *'
 
 jobs:
   compile-sketch-for-esp32:

--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -1,0 +1,67 @@
+name: Compile Sketch
+
+# The workflow will run on every push and pull request to the repository
+on:
+  workflow_dispatch:
+  # (optional) Run workflow when pushing on master/main
+  push:
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  compile-sketch-for-esp32:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        fqbn:
+          - esp32:esp32:esp32
+          - esp32:esp32:esp32s3
+          - esp32:esp32:esp32c3
+
+    steps:
+      # This step makes the contents of the repository available to the workflow
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # For more information: https://github.com/arduino/compile-sketches#readme
+      - name: Compile sketch
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: ${{ matrix.fqbn }}
+          platforms: |
+            - source-url: https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json
+              name: esp32:esp32
+          sketch-paths: |
+            - examples/
+          libraries: |
+            - source-path: ./src/
+              destination-name: HC-SR04
+
+  compile-sketch-for-esp8266:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        fqbn:
+          - esp8266:esp8266:generic
+          - esp8266:esp8266:esp8285
+
+    steps:
+      # This step makes the contents of the repository available to the workflow
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # For more information: https://github.com/arduino/compile-sketches#readme
+      - name: Compile sketch
+        uses: arduino/compile-sketches@v1
+        with:
+          fqbn: ${{ matrix.fqbn }}
+          platforms: |
+            - source-url: https://arduino.esp8266.com/stable/package_esp8266com_index.json
+              name: esp8266:esp8266
+          sketch-paths: |
+            - examples/
+          libraries: |
+            - source-path: ./src/
+              destination-name: HC-SR04

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Compile Sketch](https://github.com/d03n3rfr1tz3/HC-SR04/actions/workflows/compile-sketch.yml/badge.svg)](https://github.com/d03n3rfr1tz3/HC-SR04/actions/workflows/compile-sketch.yml)
+
 # Arduino/ESP8266/ESP32 library for HC-SR04 ultrasonic distance sensor.
 
 This library is used for measuring distance with the HC-SR04, which is an ultrasonic sensor that measures distances from 2 to 400cm. My library features a temperature correction and can utilize one trigger pin with multiple echo pins in parallel. I based this library on two other libraries.


### PR DESCRIPTION
added a build action to keep track, if the library still compiles with the latest ESP32 and ESP8266 versions.